### PR TITLE
Add the Gitpod integration

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,11 @@
+tasks:
+  - init: npm install
+    command: npm run compile:scss
+github:
+  prebuilds:
+    addBadge: true
+    addComment: false
+    addCheck: false
+    master: true
+    branches: true
+    pullRequestsFromForks: true

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@
 
 ## How To Use 🔧
 
+If you're willing to use the [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/rammcodes/Dopefolio) service, skip to the last step.
+
 From your command line, first clone Dopefolio:
 
 ```bash


### PR DESCRIPTION
Things added/changed:

- Added the [![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/rammcodes/Dopefolio) service.
  - You will have to follow the steps mentioned in #2.
  - Closes #2.
